### PR TITLE
Fixing missing ext and minor PR typo

### DIFF
--- a/docs/version-history/v3.0.md
+++ b/docs/version-history/v3.0.md
@@ -226,6 +226,7 @@ Here are all Core Extensions added between v2.0.0 and v3.0.0:
 - [Show All Recent Submissions](http://wiki.lorekeeper.me/index.php?title=Extensions:Gallery_Recent_Submissions) by [Speedy](https://github.com/SpeedyD)
 - [Staff Rewards](http://wiki.lorekeeper.me/index.php?title=Extensions:Staff_Rewards) by [itinerare](https://github.com/itinerare)
 - [Submission Drafts](http://wiki.lorekeeper.me/index.php?title=Extensions:Submission_Drafts) by [Preimpression](https://github.com/preimpression)
+- [Visual Trait Indexes Trait Modals](http://wiki.lorekeeper.me/index.php?title=Extensions:VTI_Trait_Modals) by [Moif](https://github.com/AW0005)
 
 ## v3.0.0 - Release branch (Changes since pre-release)
 ### Miscellaneous
@@ -354,4 +355,4 @@ Here are all Core Extensions added between v2.0.0 and v3.0.0:
 - Parsed rank descriptions are not set on initial setup ([PR #1280](https://github.com/lk-arpg/lorekeeper/pull/1280))
 - Notifications aren't sent to owners of characters included in gallery submissions ([PR #1281](https://github.com/lk-arpg/lorekeeper/pull/1281))
 - Custom CSS file is not reloaded when modified ([PR #1287](https://github.com/lk-arpg/lorekeeper/pull/1287))
-- Site settings admin panel description column does not use all space available ([PR #190](https://github.com/lk-arpg/lorekeeper/pull/1290))
+- Site settings admin panel description column does not use all space available ([PR #1290](https://github.com/lk-arpg/lorekeeper/pull/1290))


### PR DESCRIPTION
Added Moif's Visual Trait Indexes Trait Modals ext to the version history of v3.0, as well as a minor typo on the same page.

(This PR does not fix the link error discovered by @itinerare, that's for PR #11 to fix. I did check for additional old wiki links I forgot to edit, and there were none.)

This PR does require https://github.com/lk-arpg/lorekeeper/pull/1299 to be fully merged before it officially counts, but I have no doubts about that.