### PR TITLE
fix(version history): Accidental core ext dupe

### DIFF
--- a/docs/version-history/v3.0.md
+++ b/docs/version-history/v3.0.md
@@ -221,7 +221,6 @@ Here are all Core Extensions added between v2.0.0 and v3.0.0:
 - [Gravatar](http://wiki.lorekeeper.me/index.php?title=Extensions:Gravatar) by [ScuffedNewt](https://github.com/ScuffedNewt)
 - [MYO Image Removal](http://wiki.lorekeeper.me/index.php?title=Extensions:MYO_Image_Removal) by [itinerare](https://github.com/itinerare)
 - [Organised Traits Dropdown](http://wiki.lorekeeper.me/index.php?title=Extensions:Organised_Traits_Dropdown) by [Draginraptor](https://github.com/Draginraptor)
-- [Previous & Next buttons on Character pages](http://wiki.lorekeeper.me/index.php?title=Extensions:Character_Prev_and_Next) by [Speedy](https://github.com/SpeedyD)
 - [Scroll to Top](http://wiki.lorekeeper.me/index.php?title=Extensions:Scroll_To_Top) by [Preimpression](https://github.com/preimpression)
 - [Show All Recent Submissions](http://wiki.lorekeeper.me/index.php?title=Extensions:Gallery_Recent_Submissions) by [Speedy](https://github.com/SpeedyD)
 - [Staff Rewards](http://wiki.lorekeeper.me/index.php?title=Extensions:Staff_Rewards) by [itinerare](https://github.com/itinerare)


### PR DESCRIPTION
Core ext is already there as "[Character Prev and Next](http://wiki.lorekeeper.me/index.php?title=Extensions:Character_Prev_and_Next) by [Speedy](https://github.com/SpeedyD)".

Must've accidentally messed them up prior due to differing names. Pardon.