### PR TITLE
Add mkdocs-glightbox package

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -141,4 +141,7 @@ markdown_extensions:
   - pymdownx.superfences
   - pymdownx.details
   - pymdownx.snippets
-  
+
+plugins:
+   - glightbox
+   - search

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dev = [
     # Allows setting up redirects when renaming docs files
     "mkdocs-redirects<2.0.0,>=1.2.1",
     "mkdocs-include-markdown-plugin<8.0.0,>=7.1.4",
+    "mkdocs-glightbox>=0.4.0",
 ]
 
 [tool.uv]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.9"
 resolution-markers = [
     "python_full_version >= '3.12'",
@@ -218,6 +218,7 @@ dev = [
     { name = "mdx-truly-sane-lists" },
     { name = "mike" },
     { name = "mkdocs" },
+    { name = "mkdocs-glightbox" },
     { name = "mkdocs-include-markdown-plugin" },
     { name = "mkdocs-material" },
     { name = "mkdocs-redirects" },
@@ -231,6 +232,7 @@ dev = [
     { name = "mdx-truly-sane-lists", specifier = ">=1.3,<2.0" },
     { name = "mike", specifier = ">=2.1.3,<3" },
     { name = "mkdocs", specifier = ">=1.6,<1.7" },
+    { name = "mkdocs-glightbox", specifier = ">=0.4.0" },
     { name = "mkdocs-include-markdown-plugin", specifier = ">=7.1.4,<8.0.0" },
     { name = "mkdocs-material", specifier = "==9.6.4" },
     { name = "mkdocs-redirects", specifier = ">=1.2.1,<2.0.0" },
@@ -407,6 +409,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/98/f5/ed29cd50067784976f25ed0ed6fcd3c2ce9eb90650aa3b2796ddf7b6870b/mkdocs_get_deps-0.2.0.tar.gz", hash = "sha256:162b3d129c7fad9b19abfdcb9c1458a651628e4b1dea628ac68790fb3061c60c", size = 10239, upload-time = "2023-11-20T17:51:09.981Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9f/d4/029f984e8d3f3b6b726bd33cafc473b75e9e44c0f7e80a5b29abc466bdea/mkdocs_get_deps-0.2.0-py3-none-any.whl", hash = "sha256:2bf11d0b133e77a0dd036abeeb06dec8775e46efa526dc70667d8863eefc6134", size = 9521, upload-time = "2023-11-20T17:51:08.587Z" },
+]
+
+[[package]]
+name = "mkdocs-glightbox"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/5a/0bc456397ba0acc684b5b1daa4ca232ed717938fd37198251d8bcc4053bf/mkdocs-glightbox-0.4.0.tar.gz", hash = "sha256:392b34207bf95991071a16d5f8916d1d2f2cd5d5bb59ae2997485ccd778c70d9", size = 32010, upload-time = "2024-05-06T14:31:43.063Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/72/b0c2128bb569c732c11ae8e49a777089e77d83c05946062caa19b841e6fb/mkdocs_glightbox-0.4.0-py3-none-any.whl", hash = "sha256:e0107beee75d3eb7380ac06ea2d6eac94c999eaa49f8c3cbab0e7be2ac006ccf", size = 31154, upload-time = "2024-05-06T14:31:41.011Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Just adds mkdocs's main (only?) lightbox option, [mkdocs-glightbox](https://github.com/blueswen/mkdocs-glightbox). Will be useful for image-heavy sections (such as guides). 

- I didn't configure any settings, because the defaults seemed to fit our needs perfectly fine.
- People report it's a little bit of a buggy plugin, but my testing seemed to be fine? I believe we're not planning to do anything complicated regarding images, so it's probably fine for our needs. (and there doesn't seem to be much of an alternative anyway...)
- After manually configuring the plugins section, it's necessary to explicitly define the search plugin, so there's also that.

Thanks for your time!