### PR TITLE
Version history update [180825]

### DIFF
--- a/docs/version-history/v3.0.md
+++ b/docs/version-history/v3.0.md
@@ -252,7 +252,7 @@ Here are all Core Extensions added between v2.0.0 and v3.0.0:
 - Show 24 MYO slots per page instead of 30 ([PR #1238](https://github.com/lk-arpg/lorekeeper/pull/1238))
 - Update footer GitHub repo link ([PR #1255](https://github.com/lk-arpg/lorekeeper/pull/1255))
 - Updated contributing info ([PR #1303](https://github.com/lk-arpg/lorekeeper/pull/1303))
-- Implement eager loading for submission characters, images [PR #1319](https://github.com/lk-arpg/lorekeeper/pull/1319))
+- Implement eager loading for submission characters, images ([PR #1319](https://github.com/lk-arpg/lorekeeper/pull/1319))
 - Refactor stack name retrieval in character inventories ([PR #1318](https://github.com/lk-arpg/lorekeeper/pull/1318))
 
 ### Bug Fixes

--- a/docs/version-history/v3.0.md
+++ b/docs/version-history/v3.0.md
@@ -3,7 +3,7 @@ This page contains all updates made for version 3.0.0 of Lorekeeper.
 
 For upgrade instructions, please follow the [v3.0.0 upgrade guide](../../guides/upgrade/).
 
-This page was last updated with announcement **[110825]**.
+This page was last updated with announcement **[180825]**.
 
 ## v3.0.0 (Pre-release)
 [Release notes](https://github.com/lk-arpg/lorekeeper/releases/tag/v3.0.0-pre1)
@@ -253,6 +253,7 @@ Here are all Core Extensions added between v2.0.0 and v3.0.0:
 - Update footer GitHub repo link ([PR #1255](https://github.com/lk-arpg/lorekeeper/pull/1255))
 - Updated contributing info ([PR #1303](https://github.com/lk-arpg/lorekeeper/pull/1303))
 - Implement eager loading for submission characters, images [PR #1319](https://github.com/lk-arpg/lorekeeper/pull/1319))
+- Refactor stack name retrieval in character inventories ([PR #1318](https://github.com/lk-arpg/lorekeeper/pull/1318))
 
 ### Bug Fixes
 - Option to copy character slug is provided for MYO slots ([PR #756](https://github.com/lk-arpg/lorekeeper/pull/756))
@@ -361,3 +362,5 @@ Here are all Core Extensions added between v2.0.0 and v3.0.0:
 - Attempting to display user alias errors if no primary alias is set ([PR #1314](https://github.com/lk-arpg/lorekeeper/pull/1314))
 - Species and/or rarity can be removed when editing character image traits ([PR #1315](https://github.com/lk-arpg/lorekeeper/pull/1315))
 - ReCaptcha is missing on alias register view ([PR #1317](https://github.com/lk-arpg/lorekeeper/pull/1317))
+- Rank descriptions cannot be cleared ([PR #1323](https://github.com/lk-arpg/lorekeeper/pull/1323))
+- Rank info "help" icon shows on user profiles even if rank description is empty ([PR #1322](https://github.com/lk-arpg/lorekeeper/pull/1322))


### PR DESCRIPTION
Updates the Version History for v3.0.0 as per announcement [180825]

Includes minor fix for previous update; forgot a single `(`.