### PR TITLE
feat(guides): add clarification for common blockers in windows guides

### DIFF
--- a/docs/guides/dev-setup/dev-windows.md
+++ b/docs/guides/dev-setup/dev-windows.md
@@ -67,7 +67,7 @@ We are now going to use SourceGit to make a copy of Lorekeeper. This will be you
 
     As of this writing, the main branch of LK is on version 2.1. You may wish to be on a higher version, such as the release branch version 3.0. 
     
-    **Please note that is *extremely discouraged* to put your site on the develop branch of Lorekeeper.** Please see our [dev intro](../dev-intro#navigating-branches) regarding different branches.
+    **Please note that is *extremely discouraged* to put your site on the develop branch of Lorekeeper.** Please see our [dev intro](../dev-intro.md#navigating-branches) regarding different branches.
 
     SourceGit will clone the main branch by default. If you wish to update to version 3.0 or otherwise the current release, branch, simply pull that branch into your local branch with right click -> "Merge into main".
 
@@ -280,6 +280,9 @@ MIX_PUSHER_APP_CLUSTER="${PUSHER_APP_CLUSTER}"
 <figure markdown="span">
   ![alt text](../../images/dev-setup/windows/running-lk-9.png){ width="600" }
 </figure>
+
+!!! warn "Creating Your Database"
+    At this step, you need to create your database, if you haven't already. You may need to do this if you were following the XAMPP guide. If you need to, [return to PHPMyAdmin and create your database](../software-setup/software-windows.md#configuring-phpmyadmin).
 
 10. Next, type in `php artisan migrate`. This will populate the database with all of the tables that Lorekeeper needs to function. You'll see a LOT of text start to fly by. It should look like this when completed:
 

--- a/docs/guides/software-setup/software-windows.md
+++ b/docs/guides/software-setup/software-windows.md
@@ -129,28 +129,30 @@ Within this guide, we will be installing the following software:
   ![Stopping and starting XAMPP](../../images/software-setup/windows/xampp-stop-start.png){ width="600" }
 </figure>
 
-!!! info 
-    Apache may fail to start if the folder `C:/xampp/htdocs/lorekeeper/public` does not exist. **This is OK.** Continue with this guide, and Apache will start after you have cloned LK.
+!!! warn "Apache Failing to Start"
+    Apache will fail to start if the folder `C:/xampp/htdocs/lorekeeper/public` does not exist. PHPMyAdmin will not be accessible unless Apache has started. **This is OK.** Skip the PHPMyAdmin section and return after you've cloned Lorekeeper.
 
-8. Next, we are going to make one more change in anticipation of installing Lorekeeper. Click the "Admin" button next to MySQL.
+### Configuring PHPMyAdmin
+
+1. Next, we are going to make one more change in anticipation of installing Lorekeeper. Make sure Apache has started, then click the "Admin" button next to MySQL.
 
 <figure markdown="span">
   ![pressing the mysql admin button](../../images/software-setup/windows/mysql-admin.png){ width="600" }
 </figure>
 
-9. This will open a window similar to this in your browser. This is PHPMyAdmin, and it is where we control how most of the data is stored for Lorekeeper. Click "New".
+2. This will open a window similar to this in your browser. This is PHPMyAdmin, and it is where we control how most of the data is stored for Lorekeeper. Click "New".
 
 <figure markdown="span">
   ![phpmyadmin front page](../../images/software-setup/windows/phpmyadmin-start.png){ width="600" }
 </figure>
 
-10. Type in `lorekeeper` or any other easy to remember name, then click "Create".
+3. Type in `lorekeeper` or any other easy to remember name, then click "Create".
 
 <figure markdown="span">
   ![creating a database in phpmyadmin](../../images/software-setup/windows/phpmyadmin-create.png){ width="600" }
 </figure>
 
-11. **Congratulations! We're done here for now.** Next, we will install the Git software needed to manage our Lorekeeper files.
+4. **Congratulations! We're done here for now.** Next, we will install the Git software needed to manage our Lorekeeper files.
 
 ## Installing Git Software
 


### PR DESCRIPTION
Had multiple people get stuck here so just some quick edits to clarify when you should go back and create your database. 

Thought about moving it around but I opted to keep the database creation part within the XAMPP guide, because how you go about creating your database is going to be specific to whether you're using XAMPP/Laragon/Valet/whatever.