### PR TITLE
feat(versionHistory): update for [220626]

### DIFF
--- a/docs/version-history/v2.1.md
+++ b/docs/version-history/v2.1.md
@@ -62,3 +62,8 @@ This is an interim release primarily for the purposes of backporting Toyhou.se a
 ### Bug Fixes
 - chore: update README and CONTRIBUTING with anti-AI policy by ([perappu](https://github.com/perappu)) ([PR #1480](https://github.com/lk-arpg/lorekeeper/pull/1480))
 - fix: patch for CRLF injection vulnerability in email inputs by ([perappu](https://github.com/perappu)) ([PR #1493](https://github.com/lk-arpg/lorekeeper/pull/1493))
+
+## v2.1.11 (Hotfix)
+[Release notes](https://github.com/lk-arpg/lorekeeper/releases/tag/v2.1.11)
+### Bug Fixes
+- fix: suppress irrelevant/duplicate security advisories by by ([perappu](https://github.com/perappu)) ([PR #1505](https://github.com/lk-arpg/lorekeeper/pull/1505))

--- a/docs/version-history/v3.0.md
+++ b/docs/version-history/v3.0.md
@@ -3,7 +3,7 @@ This page contains all updates made for version 3.0.0 of Lorekeeper.
 
 For upgrade instructions, please follow the [v3.0.0 upgrade guide](../../guides/upgrade/).
 
-This page was last updated with announcement **[080626]**.
+This page was last updated with announcement **[220626]**.
 
 ## v3.0.0 (Pre-release)
 [Release notes](https://github.com/lk-arpg/lorekeeper/releases/tag/v3.0.0-pre1)


### PR DESCRIPTION
Updates the Version History for v2.1.11 as per announcement [220626].

The Version History for v3.0.0 is unchanged except for the change in the announcement number.